### PR TITLE
Capcha for chats

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -79,7 +79,14 @@ class DevConfig:
     DATABASE_URL = 'postgresql+asyncpg://postgres:2026523@localhost:5432/postgres'  # для тестов, локальная
 
 
-class ConfigVars(ProdConfig):
+def get_settings():
+    dev_settings = bool(os.getenv('SET_DEV_SETTINGS', False))
+    if dev_settings:
+        return DevConfig
+    return ProdConfig
+
+
+class ConfigVars(get_settings()):
     # Общие настройки
     TOKEN = os.getenv('BOT_TOKEN')  # Боты разные, но значение в обоих случаях берется из ENV
 

--- a/core/config.py
+++ b/core/config.py
@@ -68,7 +68,7 @@ class DevConfig:
     LOG_CHAT: int = -1001868029361  # for mistakes
     MESSAGE_CONTAINER_CHAT: int = -4549380236
 
-    WEBHOOK_HOST = 'https://f6bb-2-132-111-33.ngrok-free.app'
+    WEBHOOK_HOST = 'https://d4ca-2a03-32c0-4-51dc-4014-c1e2-7f7e-9b7e.ngrok-free.app'
     WEBAPP_HOST = '127.0.0.1'
     WEBAPP_PORT = 8080
 

--- a/core/database_functions/db_functions.py
+++ b/core/database_functions/db_functions.py
@@ -304,30 +304,38 @@ async def db_load_chats(chats_for_db, session=async_session):
     return True
 
 
-async def db_update_strict_chats(capcha_chats, turn_off=False, session=async_session):
-    async with session() as session:
-        for chat_id in capcha_chats:
-            query = update(DBChat).where(DBChat.chat_id == chat_id).values(strict_mode=not turn_off)
-            await session.execute(query)
-            await session.commit()
-    return True
-
-
-async def db_update_capcha(strict_chats, turn_off=False, session=async_session):
-    async with session() as session:
-        for chat_id in strict_chats:
-            query = update(DBChat).where(DBChat.chat_id == chat_id).values(capcha=not turn_off)
-            await session.execute(query)
-            await session.commit()
-    return True
-
-
 async def db_get_strict_chats(session=async_session):
     async with session() as session:
         query = select(DBChat.chat_id).where(DBChat.strict_mode==True)
         result = await session.execute(query)
         strict_chats = result.scalars().all()
         return strict_chats
+
+
+async def db_update_strict_chats(strict_chats, turn_off=False, session=async_session):
+    async with session() as session:
+        for chat_id in strict_chats:
+            query = update(DBChat).where(DBChat.chat_id == chat_id).values(strict_mode=not turn_off)
+            await session.execute(query)
+            await session.commit()
+    return True
+
+
+async def db_get_capcha_chats(session=async_session):
+    async with session() as session:
+        query = select(DBChat.chat_id).where(DBChat.capcha==True)
+        result = await session.execute(query)
+        capcha_chats = result.scalars().all()
+        return capcha_chats
+
+
+async def db_update_capcha_chats(capcha_chats, turn_off=False, session=async_session):
+    async with session() as session:
+        for chat_id in capcha_chats:
+            query = update(DBChat).where(DBChat.chat_id == chat_id).values(capcha=not turn_off)
+            await session.execute(query)
+            await session.commit()
+    return True
 
 
 async def delete_old_data(async_session=async_session, days: int = 15, user_id: int = None):

--- a/core/database_functions/db_functions.py
+++ b/core/database_functions/db_functions.py
@@ -304,10 +304,19 @@ async def db_load_chats(chats_for_db, session=async_session):
     return True
 
 
-async def db_update_strict_chats(strict_chats, not_remove=True, session=async_session):
+async def db_update_strict_chats(capcha_chats, turn_off=False, session=async_session):
+    async with session() as session:
+        for chat_id in capcha_chats:
+            query = update(DBChat).where(DBChat.chat_id == chat_id).values(strict_mode=not turn_off)
+            await session.execute(query)
+            await session.commit()
+    return True
+
+
+async def db_update_capcha(strict_chats, turn_off=False, session=async_session):
     async with session() as session:
         for chat_id in strict_chats:
-            query = update(DBChat).where(DBChat.chat_id == chat_id).values(strict_mode=not_remove)
+            query = update(DBChat).where(DBChat.chat_id == chat_id).values(capcha=not turn_off)
             await session.execute(query)
             await session.commit()
     return True

--- a/core/database_functions/db_functions.py
+++ b/core/database_functions/db_functions.py
@@ -242,6 +242,25 @@ async def delete_user(user_id: int, session=async_session):
             print('Не удалось удалить пользователя, сломано: ', e)
 
 
+async def delete_mute(user_id: int, session=async_session):
+    async with session() as session:
+        # Находим пользователя по user_id и удаляем его
+        query = select(Mute).where(user_id == Mute.user_id)
+        try:
+            result: Result = await session.execute(query)
+            mute: Mute = result.scalars().first()
+            if mute:
+                await session.execute(
+                    delete(Mute).where(mute.id == Mute.id)
+                )
+                print(f'Мьют {mute.id} пользователя {user_id} удален')
+            else:
+                print(f'Мьют {mute.id} пользователя {user_id} не удален')
+            await session.commit()
+        except Exception as e:
+            print('Не удалось удалить пользователя, сломано: ', e)
+
+
 async def add_id(username: str, user_id: int, session=async_session):
     async with session() as session:
         try:

--- a/core/database_functions/db_models.py
+++ b/core/database_functions/db_models.py
@@ -80,6 +80,7 @@ class DBChat(Base):
     title: Mapped[str] = mapped_column(Text, nullable=False)
     username: Mapped[str] = mapped_column(Text, nullable=True)
     strict_mode: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    capcha: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
 
 engine: AsyncEngine = create_async_engine(

--- a/core/filters/admin_filter.py
+++ b/core/filters/admin_filter.py
@@ -72,7 +72,8 @@ class StrictChatFilter(BaseFilter):
     """
     Отделяет чаты, в которых должен работать хэндлер от тех, где не должен
     """
-    async def __call__(self, message: Message, strict_chats: list) -> bool:
+    async def __call__(self, message: Message, chat_settings: dict) -> bool:
+        strict_chats = chat_settings.get('strict_chats', [])
         if message.chat.id in strict_chats:
             return True
         return False

--- a/core/filters/filters.py
+++ b/core/filters/filters.py
@@ -77,3 +77,14 @@ class StrictChatFilter(BaseFilter):
         if message.chat.id in strict_chats:
             return True
         return False
+
+
+class CapchaChatFilter(BaseFilter):
+    """
+    Отделяет чаты, в которых должна работать капча от тех, где не должен
+    """
+    async def __call__(self, message: Message, chat_settings: dict) -> bool:
+        capcha_chats = chat_settings.get('capcha_chats', [])
+        if message.chat.id in capcha_chats:
+            return True
+        return False

--- a/core/filters/filters.py
+++ b/core/filters/filters.py
@@ -70,7 +70,7 @@ class HashTagFilter(BaseFilter):
 
 class StrictChatFilter(BaseFilter):
     """
-    Отделяет чаты, в которых должен работать хэндлер от тех, где не должен
+    Отделяет чаты, в которых должен работать стрикт мод от тех, где не должен
     """
     async def __call__(self, message: Message, chat_settings: dict) -> bool:
         strict_chats = chat_settings.get('strict_chats', [])

--- a/core/handlers/admin_group_handlers.py
+++ b/core/handlers/admin_group_handlers.py
@@ -43,6 +43,32 @@ async def strict_mode_off(message: types.Message, chat_settings: dict):
     await message.delete()
 
 
+@admin_group_router.message(Command('capcha_on'))
+async def capcha_on(message: types.Message, chat_settings: dict):
+    capcha_chats = chat_settings.get('capcha_chats', [])
+    if message.chat.id in capcha_chats:
+        msg = await message.answer('Capcha уже включена')
+    else:
+        chat_settings.setdefault('capcha_chats', []).append(message.chat.id)
+        await db_update_capcha_chats([message.chat.id])
+        msg = await message.answer('Capcha включена')
+    await delete_message(msg, 2)
+    await message.delete()
+
+
+@admin_group_router.message(Command('capcha_off'))
+async def capcha_off(message: types.Message, chat_settings: dict):
+    capcha_chats = chat_settings.get('capcha_chats', [])
+    if message.chat.id in capcha_chats:
+        await db_update_capcha_chats([message.chat.id], turn_off=True)
+        capcha_chats.remove(message.chat.id)
+        msg = await message.answer('Capcha отключена')
+    else:
+        msg = await message.answer('Capcha уже отключена')
+    await delete_message(msg, 2)
+    await message.delete()
+
+
 @admin_group_router.message(Command(commands='mute'))
 async def mute_handler(moderator_message: types.Message, bot: Bot):
     permission = await checks(moderator_message, bot)

--- a/core/handlers/admin_group_handlers.py
+++ b/core/handlers/admin_group_handlers.py
@@ -4,7 +4,7 @@ from aiogram import Router, Bot, types, F
 from aiogram.filters import Command
 
 from core import ConfigVars
-from core.database_functions.db_functions import add_lives, db_update_strict_chats
+from core.database_functions.db_functions import add_lives, db_update_strict_chats, db_update_capcha_chats
 from core.filters.admin_filter import AdminFilter
 from core.models.data_models import UserData
 from core.services.ban import ban_name
@@ -18,21 +18,23 @@ admin_group_router.message.filter(AdminFilter())
 
 
 @admin_group_router.message(Command('strict_mode_on'))
-async def strict_mode_on(message: types.Message, strict_chats: list):
+async def strict_mode_on(message: types.Message, chat_settings: dict):
+    strict_chats = chat_settings.get('strict_chats', [])
     if message.chat.id in strict_chats:
         msg = await message.answer('Strict Reply уже включен')
     else:
         strict_chats.append(message.chat.id)
-        await db_update_strict_chats(strict_chats)
+        await db_update_strict_chats([message.chat.id])
         msg = await message.answer('Strict Reply включен')
     await delete_message(msg, 2)
     await message.delete()
 
 
 @admin_group_router.message(Command('strict_mode_off'))
-async def strict_mode_off(message: types.Message, strict_chats: list):
+async def strict_mode_off(message: types.Message, chat_settings: dict):
+    strict_chats = chat_settings.get('strict_chats', [])
     if message.chat.id in strict_chats:
-        await db_update_strict_chats(strict_chats, not_remove=False)
+        await db_update_strict_chats([message.chat.id], turn_off=True)
         strict_chats.remove(message.chat.id)
         msg = await message.answer('Strict Reply отключен')
     else:

--- a/core/handlers/admin_group_handlers.py
+++ b/core/handlers/admin_group_handlers.py
@@ -1,15 +1,12 @@
-import json
-
 from aiogram import Router, Bot, types, F
 from aiogram.filters import Command
 
 from core import ConfigVars
 from core.database_functions.db_functions import add_lives, db_update_strict_chats, db_update_capcha_chats
-from core.filters.admin_filter import AdminFilter
+from core.filters.filters import AdminFilter
 from core.models.data_models import UserData
 from core.services.ban import ban_name
 from core.services.mute import mute
-from core.utils.create_redis_pool import get_conn
 from core.utils.delete_message_with_delay import delete_message
 from core.utils.text_checks import checks, get_id_from_text, get_id_from_entities
 

--- a/core/handlers/admin_private_handlers.py
+++ b/core/handlers/admin_private_handlers.py
@@ -1,6 +1,7 @@
 import json
 
 from aiogram import Router, F, Bot
+from aiogram.exceptions import TelegramBadRequest
 from aiogram.filters import Command, CommandStart
 from aiogram.enums.chat_type import ChatType
 from aiogram.types import Message, CallbackQuery
@@ -186,26 +187,7 @@ async def admin_funcs_callback(call: CallbackQuery, callback_data: BanHammer, bo
                     saved_message = json.loads(saved_message)
                     await bot.delete_messages(ConfigVars.MESSAGE_CONTAINER_CHAT, saved_message)
             await ban_name(user_id, bot)
-        case 'ban_first':
-            builder = InlineKeyboardBuilder()
-            builder.button(
-                text='Подтвердить бан',
-                callback_data=BanHammer(function='ban_last', user_id=user_id)
-            )
-            builder.button(
-                text='Отмена',
-                callback_data=BanHammer(function='show', user_id=user_id)
-            )
-            builder.adjust(1, repeat=True)
-            await bot.edit_message_reply_markup(
-                chat_id=call.message.chat.id,
-                message_id=call.message.message_id,
-                reply_markup=builder.as_markup()
-            )
-        case 'show':
-            builder = get_bh_keyboard(user_id)
-            await bot.edit_message_reply_markup(
-                chat_id=call.message.chat.id,
-                message_id=call.message.message_id,
-                reply_markup=builder.as_markup()
-            )
+            try:
+                await call.message.delete()
+            except TelegramBadRequest:
+                print('Ban, message for delete not found')

--- a/core/handlers/admin_private_handlers.py
+++ b/core/handlers/admin_private_handlers.py
@@ -8,7 +8,7 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 from core import ConfigVars
 from core.database_functions.db_functions import add_lives, delete_lives, delete_all_lives, get_last_mute
-from core.filters.admin_filter import AdminFilter
+from core.filters.filters import AdminFilter
 from core.models.data_models import AdminFunctions, UserData, BanHammer
 from core.services.ban import ban_name, get_bh_keyboard
 from core.services.mute import mute

--- a/core/handlers/debug_handlers.py
+++ b/core/handlers/debug_handlers.py
@@ -5,7 +5,7 @@ from aiogram.types import Message, Chat
 from core import ConfigVars
 from core.database_functions.db_functions import delete_user, db_load_chats
 from core.database_functions.test_db import test_simple_db
-from core.filters.admin_filter import AdminFilter
+from core.filters.filters import AdminFilter
 from core.utils.send_report import send_mute_report
 
 debug_router = Router()

--- a/core/handlers/service_handlers.py
+++ b/core/handlers/service_handlers.py
@@ -15,17 +15,20 @@ service_router.message.filter(F.content_type.in_(ConfigVars.MESSAGES_FOR_DELETE)
 
 @service_router.message(CapchaChatFilter(), F.content_type == ContentType.NEW_CHAT_MEMBERS)
 async def capcha_handler(message: Message, bot: Bot, admins: list):
+    await message.delete()
     user_id = message.from_user.id
     if user_id in admins:
         return
     last_mute = await get_last_mute(user_id)
     if last_mute:
+        print('old user joined chat')
         # не новый пользователь
         return
     data = UserData()
     data.parse_message(message, user_id=user_id)
     data.chat_id = message.chat.id
     data.reason_message = 'capcha'
+    data.admin_username = 'dimaboro'
     await add_lives(user_id)
     await mute(data=data, bot=bot)
 

--- a/core/handlers/service_handlers.py
+++ b/core/handlers/service_handlers.py
@@ -1,11 +1,33 @@
-from aiogram import Router, F
+from aiogram import Router, F, Bot
+from aiogram.enums import ContentType
 from aiogram.types import Message
 
 from core import ConfigVars
+from core.database_functions.db_functions import get_last_mute, add_lives
+from core.filters.filters import CapchaChatFilter
+from core.models.data_models import UserData
 from core.services.join_cleaner import join_cleaner
+from core.services.mute import mute
 
 service_router = Router()
 service_router.message.filter(F.content_type.in_(ConfigVars.MESSAGES_FOR_DELETE))
+
+
+@service_router.message(CapchaChatFilter(), F.content_type == ContentType.NEW_CHAT_MEMBERS)
+async def capcha_handler(message: Message, bot: Bot, admins: list):
+    user_id = message.from_user.id
+    if user_id in admins:
+        return
+    last_mute = await get_last_mute(user_id)
+    if last_mute:
+        # не новый пользователь
+        return
+    data = UserData()
+    data.parse_message(message, user_id=user_id)
+    data.chat_id = message.chat.id
+    data.reason_message = 'capcha'
+    await add_lives(user_id)
+    await mute(data=data, bot=bot)
 
 
 @service_router.message()

--- a/core/handlers/user_group_handlers.py
+++ b/core/handlers/user_group_handlers.py
@@ -15,7 +15,7 @@ from aiogram.enums import ChatType
 from aiogram.exceptions import TelegramBadRequest
 
 from core import ConfigVars
-from core.filters.admin_filter import HashTagFilter, StrictChatFilter
+from core.filters.filters import HashTagFilter, StrictChatFilter
 from redis.asyncio import Redis
 
 from core.services.ban import get_bh_keyboard

--- a/core/middlewares/config_mw.py
+++ b/core/middlewares/config_mw.py
@@ -17,8 +17,7 @@ class ConfigMiddleware(BaseMiddleware):
     ) -> Any:
         if isinstance(event.message, Message):
             message = event.message
-            if message.from_user.username:
-                await add_user_to_db(message=message, bot=data['bot'])
+            await add_user_to_db(message=message, bot=data['bot'])
         try:
             await handler(event, data)
         except TelegramBadRequest:

--- a/core/models/data_models.py
+++ b/core/models/data_models.py
@@ -75,7 +75,7 @@ class UserData(BaseData):
             self.admin_username = message.from_user.username
             self.chat_id = message.chat.id
             self.chat_username = message.chat.username
-            self.reason_message = ' '.join(message.text.split()[2:])
+            self.reason_message = ' '.join(message.text.split()[2:]) if isinstance(message.text, str) else ''
             self.is_reply = False
         else:
             raise Exception

--- a/core/services/ban.py
+++ b/core/services/ban.py
@@ -19,7 +19,7 @@ def get_bh_keyboard(user_id):
     builder = InlineKeyboardBuilder()
     builder.button(
         text='Забанить',
-        callback_data=BanHammer(user_id=user_id, function='ban_first'),
+        callback_data=BanHammer(user_id=user_id, function='ban_last'),
     )
     builder.adjust(1, repeat=True)
     return builder

--- a/core/services/mute.py
+++ b/core/services/mute.py
@@ -9,11 +9,12 @@ from core.utils.restrict import restrict
 from core.utils.send_report import send_bug_report, send_mute_report
 
 
-async def mute(data: UserData, bot: Bot, chats: List[int] = ConfigVars.CHATS,
+async def mute(data: UserData, bot: Bot, silent: bool = False, chats: List[int] = ConfigVars.CHATS,
                permissions: types.ChatPermissions = ConfigVars.MUTE_SETTINGS):
     """
     Мьют с занесением данных в бд и отчетом.
     Args:
+        silent: True, если нужно без отчета о мьюте
         data: данные о мьюте в формате UserData
         bot: бот
         chats: Список чатов, в которых мьютим
@@ -34,11 +35,12 @@ async def mute(data: UserData, bot: Bot, chats: List[int] = ConfigVars.CHATS,
         await send_bug_report(problem=problem, **data.as_dict(), bot=bot)
         return False
     # отправляем отчет в канал
-    try:
-        await send_mute_report(**data.as_dict(), bot=bot)
-    except Exception as e:
-        problem = f'Мьют, не удалось отправить отчет. Ошибка: {e}'
-        await send_bug_report(problem=problem, **data.as_dict(), bot=bot)
-        return False
+    if not silent:
+        try:
+            await send_mute_report(**data.as_dict(), bot=bot)
+        except Exception as e:
+            problem = f'Мьют, не удалось отправить отчет. Ошибка: {e}'
+            await send_bug_report(problem=problem, **data.as_dict(), bot=bot)
+            return False
     # Мьют прошел (минимум в одном чате), инфа в базе, отчет в канале
     return True

--- a/core/services/unmute.py
+++ b/core/services/unmute.py
@@ -4,7 +4,7 @@ from aiogram import Bot, types
 from aiogram.exceptions import TelegramBadRequest
 
 from core import ConfigVars
-from core.database_functions.db_functions import get_user, get_last_mute, add_lives, db_unmute
+from core.database_functions.db_functions import get_user, get_last_mute, add_lives, db_unmute, delete_mute
 from core.services.status import status
 from core.utils.restrict import restrict
 from core.utils.send_report import send_bug_report
@@ -55,6 +55,8 @@ async def unmute(user_id, bot: Bot, chats: List[int] = ConfigVars.CHATS,
     if unmuted is False:
         answer = 'Вы разблокированы. Не удалось обновить данные в базе, отчет направлен разработчику.'
         return False, answer
+    if user_last_mute.get('moderator_message') == 'capcha':
+        await delete_mute(user_id)
     answer = await status(user_id, bot)
     return True, answer
 

--- a/core/utils/add_user_to_db.py
+++ b/core/utils/add_user_to_db.py
@@ -6,7 +6,7 @@ from core.utils.send_report import send_bug_report
 
 
 async def add_user_to_db(message: types.Message, bot: Bot):
-    username = message.from_user.username
+    username = message.from_user.username if isinstance(message.from_user.username, str) else 'None'
     user_id = message.from_user.id
 
     user = await add_user(user_id=user_id)

--- a/core/utils/get_username_from_text.py
+++ b/core/utils/get_username_from_text.py
@@ -1,11 +1,13 @@
 def is_username(text: str):
     # если в тексте есть слово, начинающееся с @, возвращает это слово
     # в противном случае возвращает None
+    if not isinstance(text, str):
+        return
     text_list = text.strip().split()
     for word in text_list:
         if word[0] == '@':
             return word[1:]
-    return None
+    return
 
 
 def get_status_from_text(text: str):

--- a/core/utils/text_checks.py
+++ b/core/utils/text_checks.py
@@ -25,9 +25,10 @@ async def checks(moderator_message: Message, bot: Bot):
             return True, user_id
         if member.status == 'member' or member.status == 'left':
             return True, user_id
-
-        return False, 'Пользователя нельзя замьютить'
-
+        if member.status in ('administrator', 'creator'):
+            return False, 'Пользователя нельзя замьютить, он админ'
+        if member.status == 'restricted':
+            return False, 'Пользователь уже в мьюте'
     if not moderator_message.reply_to_message:
         return False, 'Пользователь не найден'
 

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from aiohttp import web
 # settings import
 from core.config import ConfigVars
 # full database import
-from core.database_functions.db_functions import create_db, db_get_strict_chats
+from core.database_functions.db_functions import create_db, db_get_strict_chats, db_get_capcha_chats
 from core.handlers import all_routers
 # GROUP FUNCTION IMPORTS
 from core.middlewares.config_mw import ConfigMiddleware
@@ -31,7 +31,8 @@ async def on_startup(bot: Bot):
     await setup_schedule()
     admins = await get_admins_ids(bot)
     dp['admins'] = admins
-    dp['strict_chats'] = await db_get_strict_chats()
+    dp['chat_settings'] = {'strict_chats': await db_get_strict_chats(),
+                           'capcha_chats': await db_get_capcha_chats()}
     await bot.set_webhook(url=ConfigVars.WEBHOOK_URL,
                           drop_pending_updates=True,
                           secret_token=ConfigVars.WEBHOOK_SECRET)


### PR DESCRIPTION
I have created captcha service
- db switchers - for saving  captcha state on / off in chats if bot reloaded
- turn on / of handlers - for managing this service in chats
- wrote captcha handler - it mutes all new users when joining chat and follows them to unblock in bot 
And some fixes
- set dispatcher var chat_settings instead of strict mode. Strict mode moved into chat settings)
- create automatic switching between prod and dev configs
- rename admin_filters to filters
- add silent mute - without sending report
- set middleware to add all users to db, not only with username
- add new explain messages for admins in mute func - in checks funk, at real
- delete ban confirm button - now ban in 